### PR TITLE
fix: support webpack4

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (content) {
 
   // Calculate sprite symbol id
   var id = loaderUtils.interpolateName(this, config.name, {
-    context: this.options.context,
+    context: this.options.context || this.context,
     content: content,
     regExp: config.regExp
   });


### PR DESCRIPTION
[Bugfix] Support webpack4

Error detail: 

```
TypeError: Cannot read property 'context' of undefined
    at Object.module.exports (/Users/william/Code/work/web/mall/node_modules/svg-sprite-loader/index.js:34:27)
```